### PR TITLE
docs: add CI status badge to README

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,6 @@ repos:
     rev: 24.10.0
     hooks:
       - id: black
-        language_version: python3.11
         files: ^backend/
 
   - repo: https://github.com/PyCQA/flake8

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -91,6 +91,10 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -144,7 +148,7 @@
         "filename": "README.md",
         "hashed_secret": "564e340cd48437d2dfe876ee154cc99dc4d0d137",
         "is_verified": false,
-        "line_number": 49
+        "line_number": 51
       }
     ],
     "backend\\alembic.ini": [
@@ -193,5 +197,5 @@
       }
     ]
   },
-  "generated_at": "2026-04-30T03:48:32Z"
+  "generated_at": "2026-04-30T04:19:24Z"
 }

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # ShiftControl
 
+![CI](https://github.com/LyutinAl/ShiftControl/actions/workflows/ci.yml/badge.svg)
+
 Внутренняя веб-система для инженерной команды: ведение журналов смен, учёт инцидентов, внутренние сообщения, wiki и аудит-лог действий.
 
 ## Стек


### PR DESCRIPTION
Fix pre-commit config: remove python3.11 version pin from black hook to support Python 3.14.