### PR TITLE
feat: add Docker containerization and CI image publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@ name: CI
 on:
   pull_request:
     branches: [main]
+  push:
+    branches: [main]
 
 jobs:
   lint:
@@ -28,8 +30,8 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     env:
-      DATABASE_URL: postgresql+psycopg://postgres:postgres@localhost:5432/testdb
-      SECRET_KEY: ci_test_secret_key_not_used_in_unit_tests
+      DATABASE_URL: postgresql+psycopg://postgres:postgres@localhost:5432/testdb  # pragma: allowlist secret
+      SECRET_KEY: ci_test_secret_key_not_used_in_unit_tests  # pragma: allowlist secret
     steps:
       - uses: actions/checkout@v4
 
@@ -59,3 +61,31 @@ jobs:
 
       - name: Run bandit
         run: bandit -r backend/ -x backend/venv,backend/tests -ll
+
+  publish:
+    name: Build & Push Image
+    needs: [lint, test, security]
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: ./backend
+          file: ./backend/Dockerfile
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/shiftcontrol:latest
+            ghcr.io/${{ github.repository_owner }}/shiftcontrol:${{ github.sha }}

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,24 +1,14 @@
-FROM python:3.14-slim
-
-WORKDIR /app
-
-# Устанавливаем зависимости отдельным слоем — Docker кэширует его
-# пока requirements.txt не изменится
+FROM python:3.14-slim AS builder
+WORKDIR /build
 COPY requirements.txt .
-RUN pip install --no-cache-dir --timeout=120 \
-    --trusted-host pypi.org \
-    --trusted-host pypi.python.org \
-    --trusted-host files.pythonhosted.org \
-    -r requirements.txt
+RUN pip install --no-cache-dir --prefix=/install -r requirements.txt
 
-# Копируем исходный код
-COPY . .
-
-# Создаём папку для медиафайлов
-RUN mkdir -p media/wiki
-
-COPY entrypoint.sh .
-RUN chmod +x entrypoint.sh
-
-# entrypoint.sh сначала прогоняет миграции, потом запускает сервер
+FROM python:3.14-slim AS runtime
+WORKDIR /app
+RUN useradd -r -u 1001 appuser
+COPY --from=builder /install /usr/local
+COPY --chown=appuser:root . .
+RUN mkdir -p media/wiki && chmod +x entrypoint.sh
+USER appuser
+EXPOSE 8000
 ENTRYPOINT ["./entrypoint.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,65 @@
+services:
+  frontend:
+    build: ./frontend
+    container_name: shiftcontrol_frontend
+    restart: unless-stopped
+    ports:
+      - "80:80"
+    depends_on:
+      - backend
+    networks:
+      - internal
+
+  backend:
+    build: ./backend
+    container_name: shiftcontrol_backend
+    restart: unless-stopped
+    env_file: .env
+    environment:
+      DATABASE_URL: postgresql+psycopg://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}
+    volumes:
+      - media_data:/app/media
+    depends_on:
+      db:
+        condition: service_healthy
+      cache:
+        condition: service_started
+    networks:
+      - internal
+
+  db:
+    image: postgres:16-alpine
+    container_name: shiftcontrol_db
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB}
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - internal
+
+  cache:
+    image: redis:7-alpine
+    container_name: shiftcontrol_cache
+    restart: unless-stopped
+    command: redis-server --appendonly yes
+    volumes:
+      - redis_data:/data
+    networks:
+      - internal
+
+volumes:
+  postgres_data:
+  redis_data:
+  media_data:
+
+networks:
+  internal:
+    driver: bridge

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:22-alpine AS builder
+WORKDIR /build
+COPY package*.json .
+RUN npm ci
+COPY . .
+RUN npm run build
+
+FROM nginx:alpine AS runtime
+COPY --from=builder /build/dist /usr/share/nginx/html
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+EXPOSE 80

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,0 +1,17 @@
+server {
+    listen 80;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    location ~ ^/(auth|users|shifts|incidents|messages|wiki|audit|docs|openapi.json|media)(/|$) {
+        proxy_pass http://backend:8000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}


### PR DESCRIPTION
- Convert backend/Dockerfile to multi-stage build (builder + runtime stages)
- Add frontend/Dockerfile: node:22-alpine build stage + nginx:alpine runtime
- Add frontend/nginx.conf: serves React SPA and proxies API routes to backend
- Add docker-compose.yml: frontend, backend, db (postgres:16-alpine), cache (redis:7-alpine) all isolated in internal network; only port 80 exposed via frontend nginx
- Extend CI pipeline with publish job: builds and pushes backend image to GHCR on push to main after lint + test + security pass
- Fix pre-commit black hook: language_version python3.11 -> python3