### PR TITLE
feat(monitoring): add alerting rules, Alertmanager config, and SLI/SL…

### DIFF
--- a/monitoring/.env.example
+++ b/monitoring/.env.example
@@ -1,0 +1,13 @@
+# Yandex SMTP (используйте App Password, не основной пароль)
+# Включить: Яндекс ID -> Безопасность -> Пароли приложений
+SMTP_HOST=smtp.yandex.ru:465
+SMTP_FROM=your-login@yandex.ru
+SMTP_USERNAME=your-login@yandex.ru
+SMTP_PASSWORD=your-app-password
+
+# Куда отправлять алерты
+ALERT_EMAIL_TO=your-login@yandex.ru
+
+# Grafana admin
+GF_SECURITY_ADMIN_USER=admin
+GF_SECURITY_ADMIN_PASSWORD=change-me

--- a/monitoring/alertmanager/alertmanager.yml
+++ b/monitoring/alertmanager/alertmanager.yml
@@ -1,0 +1,73 @@
+global:
+  resolve_timeout: 5m
+  smtp_smarthost: '${SMTP_HOST}'
+  smtp_from: '${SMTP_FROM}'
+  smtp_auth_username: '${SMTP_USERNAME}'
+  smtp_auth_password: '${SMTP_PASSWORD}'  # pragma: allowlist secret
+  smtp_require_tls: false
+
+route:
+  receiver: 'email-default'
+  group_by: ['alertname', 'severity']
+  group_wait: 30s
+  group_interval: 5m
+  repeat_interval: 4h
+
+  routes:
+    - match:
+        severity: critical
+      receiver: 'email-critical'
+      continue: true
+
+    - match:
+        severity: warning
+      receiver: 'email-warning'
+
+receivers:
+  - name: 'email-default'
+    email_configs:
+      - to: '${ALERT_EMAIL_TO}'
+        send_resolved: true
+        headers:
+          Subject: '[{{ .Status | toUpper }}] {{ .CommonLabels.alertname }}'
+        html: |
+          <h2>{{ .CommonLabels.alertname }}</h2>
+          <p><strong>Status:</strong> {{ .Status }}</p>
+          <p><strong>Severity:</strong> {{ .CommonLabels.severity }}</p>
+          <p>{{ .CommonAnnotations.description }}</p>
+          {{ if .CommonAnnotations.runbook_url }}
+          <p><a href="{{ .CommonAnnotations.runbook_url }}">Runbook</a></p>
+          {{ end }}
+
+  - name: 'email-critical'
+    email_configs:
+      - to: '${ALERT_EMAIL_TO}'
+        send_resolved: true
+        headers:
+          Subject: '[CRITICAL] {{ .CommonLabels.alertname }}'
+        html: |
+          <h2 style="color: red;">CRITICAL: {{ .CommonLabels.alertname }}</h2>
+          {{ range .Alerts.Firing }}
+          <p><strong>Started:</strong> {{ .StartsAt }}</p>
+          {{ end }}
+          <p><strong>Description:</strong> {{ .CommonAnnotations.description }}</p>
+          {{ if .CommonAnnotations.runbook_url }}
+          <p><a href="{{ .CommonAnnotations.runbook_url }}">Runbook</a></p>
+          {{ end }}
+
+  - name: 'email-warning'
+    email_configs:
+      - to: '${ALERT_EMAIL_TO}'
+        send_resolved: true
+        headers:
+          Subject: '[WARNING] {{ .CommonLabels.alertname }}'
+        html: |
+          <h2 style="color: orange;">WARNING: {{ .CommonLabels.alertname }}</h2>
+          <p>{{ .CommonAnnotations.description }}</p>
+
+inhibit_rules:
+  - source_match:
+      severity: 'critical'
+    target_match:
+      severity: 'warning'
+    equal: ['alertname', 'instance']

--- a/monitoring/alertmanager/start.sh
+++ b/monitoring/alertmanager/start.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+set -e
+
+sed \
+  -e "s|\${SMTP_HOST}|${SMTP_HOST}|g" \
+  -e "s|\${SMTP_FROM}|${SMTP_FROM}|g" \
+  -e "s|\${SMTP_USERNAME}|${SMTP_USERNAME}|g" \
+  -e "s|\${SMTP_PASSWORD}|${SMTP_PASSWORD}|g" \
+  -e "s|\${ALERT_EMAIL_TO}|${ALERT_EMAIL_TO}|g" \
+  /etc/alertmanager/alertmanager.yml.tmpl > /tmp/alertmanager.yml
+
+exec /bin/alertmanager \
+  --config.file=/tmp/alertmanager.yml \
+  --storage.path=/alertmanager

--- a/monitoring/docker-compose.yml
+++ b/monitoring/docker-compose.yml
@@ -25,11 +25,11 @@ services:
       - ./grafana/dashboards:/etc/grafana/dashboards
       - grafana_data:/var/lib/grafana
     environment:
-      - GF_SECURITY_ADMIN_USER=admin
-      - GF_SECURITY_ADMIN_PASSWORD=admin123  # pragma: allowlist secret
+      - GF_SECURITY_ADMIN_USER=${GF_SECURITY_ADMIN_USER}
+      - GF_SECURITY_ADMIN_PASSWORD=${GF_SECURITY_ADMIN_PASSWORD}  # pragma: allowlist secret
       - GF_USERS_ALLOW_SIGN_UP=false
     ports:
-      - "3000:3000"
+      - "3200:3000"
     networks:
       - monitoring
     restart: unless-stopped

--- a/monitoring/docker-compose.yml
+++ b/monitoring/docker-compose.yml
@@ -65,14 +65,15 @@ services:
       - loki
 
   alertmanager:
-    image: prom/alertmanager:v0.26.0
+    image: prom/alertmanager:v0.27.0
     container_name: alertmanager
+    env_file:
+      - .env
     volumes:
-      - ./alertmanager/alertmanager.yml:/etc/alertmanager/alertmanager.yml
+      - ./alertmanager/alertmanager.yml:/etc/alertmanager/alertmanager.yml.tmpl:ro
+      - ./alertmanager/start.sh:/start.sh:ro
       - alertmanager_data:/alertmanager
-    command:
-      - '--config.file=/etc/alertmanager/alertmanager.yml'
-      - '--storage.path=/alertmanager'
+    entrypoint: ["/bin/sh", "/start.sh"]
     ports:
       - "9093:9093"
     networks:

--- a/monitoring/documentation/slo_sli_definitions.md
+++ b/monitoring/documentation/slo_sli_definitions.md
@@ -1,0 +1,82 @@
+# SLI/SLO для ShiftControl API
+
+## SLI 1: Доступность (Availability)
+
+**Формула:** `(Успешные запросы / Все запросы) * 100%`
+
+**Цель (SLO):** 99.9% за 30 дней (~43 минуты простоя в месяц)
+
+**Метрика:**
+```promql
+(
+  sum(rate(http_requests_total{status_code=~"2..|3.."}[5m]))
+  /
+  sum(rate(http_requests_total[5m]))
+) * 100
+```
+
+**Алерт:** `HighErrorRate` — срабатывает при уровне 5xx > 5% в течение 5 минут
+
+---
+
+## SLI 2: Задержка (Latency)
+
+**Формула:** 95-й перцентиль времени ответа
+
+**Цель (SLO):** P95 < 500 мс за 5 минут
+
+**Метрика:**
+```promql
+histogram_quantile(0.95,
+  rate(http_request_duration_seconds_bucket[5m])
+)
+```
+
+**Алерт:** `HighLatency` — срабатывает при P95 > 500 мс в течение 10 минут
+
+---
+
+## SLI 3: Частота ошибок (Error Rate)
+
+**Формула:** `(5xx запросы / Все запросы) * 100%`
+
+**Цель (SLO):** < 1% за 5 минут
+
+**Метрика:**
+```promql
+(
+  sum(rate(http_requests_total{status_code=~"5.."}[5m]))
+  /
+  sum(rate(http_requests_total[5m]))
+) * 100
+```
+
+**Алерт:** `HighErrorRate` (severity: critical, порог 5%)
+
+---
+
+## SLI 4: Насыщение CPU (Saturation)
+
+**Формула:** Средний процент использования CPU хоста
+
+**Цель (SLO):** < 80% в течение 15 минут
+
+**Метрика:**
+```promql
+(
+  1 - avg(rate(node_cpu_seconds_total{mode="idle"}[5m]))
+) * 100
+```
+
+**Алерт:** `HighCPUUsage` — срабатывает при CPU > 80% в течение 5 минут
+
+---
+
+## Сводная таблица
+
+| SLI | Формула | SLO | Алерт |
+|-----|---------|-----|-------|
+| Доступность | `successful_requests / total_requests` | 99.9% / 30 дней | HighErrorRate |
+| Задержка P95 | `histogram_quantile(0.95, ...)` | < 500 мс | HighLatency |
+| Частота ошибок | `5xx / total * 100` | < 1% | HighErrorRate |
+| Насыщение CPU | `(1 - idle_cpu) * 100` | < 80% | HighCPUUsage |

--- a/monitoring/grafana/dashboards/api-golden-signals.json
+++ b/monitoring/grafana/dashboards/api-golden-signals.json
@@ -1,0 +1,241 @@
+{
+  "title": "API Golden Signals",
+  "uid": "api-golden-signals",
+  "tags": ["api", "golden-signals"],
+  "refresh": "30s",
+  "schemaVersion": 38,
+  "time": { "from": "now-1h", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "version": 1,
+  "panels": [
+    {
+      "id": 1,
+      "title": "Request Rate (RPS)",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "sum(rate(http_requests_total[5m]))",
+          "legendFormat": "rps",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "orientation": "auto",
+        "colorMode": "value",
+        "graphMode": "area"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "decimals": 2,
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 2,
+      "title": "Error Rate (%)",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "(sum(rate(http_requests_total{status_code=~\"5..\"}[5m])) or vector(0)) / (sum(rate(http_requests_total[5m])) or vector(1)) * 100",
+          "legendFormat": "errors %",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "orientation": "auto",
+        "colorMode": "background",
+        "graphMode": "area"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "decimals": 2,
+          "min": 0,
+          "max": 100,
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 1 },
+              { "color": "red", "value": 5 }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 3,
+      "title": "Latency P95 (s)",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 6, "x": 12, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket[5m])) by (le))",
+          "legendFormat": "p95",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "orientation": "auto",
+        "colorMode": "background",
+        "graphMode": "area"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "decimals": 3,
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 0.5 },
+              { "color": "red", "value": 1 }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 4,
+      "title": "CPU Saturation (%)",
+      "type": "gauge",
+      "gridPos": { "h": 4, "w": 6, "x": 18, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "(1 - avg(rate(node_cpu_seconds_total{mode=\"idle\"}[5m]))) * 100",
+          "legendFormat": "cpu %",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "orientation": "auto",
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "min": 0,
+          "max": 100,
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 70 },
+              { "color": "red", "value": 85 }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 5,
+      "title": "Latency Percentiles over Time",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 4 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, sum(rate(http_request_duration_seconds_bucket[5m])) by (le))",
+          "legendFormat": "P50",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket[5m])) by (le))",
+          "legendFormat": "P95",
+          "refId": "B"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum(rate(http_request_duration_seconds_bucket[5m])) by (le))",
+          "legendFormat": "P99",
+          "refId": "C"
+        }
+      ],
+      "options": {
+        "tooltip": { "mode": "multi" },
+        "legend": { "displayMode": "list", "placement": "bottom" }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "custom": { "lineWidth": 2, "fillOpacity": 5 }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 6,
+      "title": "Request Rate by Status over Time",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 4 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "sum(rate(http_requests_total{status_code=~\"2..\"}[5m]))",
+          "legendFormat": "2xx",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(rate(http_requests_total{status_code=~\"4..\"}[5m]))",
+          "legendFormat": "4xx",
+          "refId": "B"
+        },
+        {
+          "expr": "sum(rate(http_requests_total{status_code=~\"5..\"}[5m]))",
+          "legendFormat": "5xx",
+          "refId": "C"
+        }
+      ],
+      "options": {
+        "tooltip": { "mode": "multi" },
+        "legend": { "displayMode": "list", "placement": "bottom" }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": { "lineWidth": 2, "fillOpacity": 10 }
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "5xx" },
+            "properties": [{ "id": "color", "value": { "fixedColor": "red", "mode": "fixed" } }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "4xx" },
+            "properties": [{ "id": "color", "value": { "fixedColor": "yellow", "mode": "fixed" } }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "2xx" },
+            "properties": [{ "id": "color", "value": { "fixedColor": "green", "mode": "fixed" } }]
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/monitoring/grafana/dashboards/infrastructure.json
+++ b/monitoring/grafana/dashboards/infrastructure.json
@@ -1,0 +1,157 @@
+{
+  "title": "Infrastructure (Node Exporter)",
+  "uid": "infrastructure",
+  "tags": ["infrastructure", "node-exporter"],
+  "refresh": "30s",
+  "schemaVersion": 38,
+  "time": { "from": "now-1h", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "version": 1,
+  "panels": [
+    {
+      "id": 1,
+      "title": "CPU Usage (%)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "(1 - avg by (instance) (rate(node_cpu_seconds_total{mode=\"idle\"}[5m]))) * 100",
+          "legendFormat": "CPU {{ instance }}",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "tooltip": { "mode": "single" },
+        "legend": { "displayMode": "list", "placement": "bottom" }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "min": 0,
+          "max": 100,
+          "custom": { "lineWidth": 2, "fillOpacity": 15 },
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 70 },
+              { "color": "red", "value": 85 }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 2,
+      "title": "Memory Usage (%)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "(1 - node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes) * 100",
+          "legendFormat": "Memory used %",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "tooltip": { "mode": "single" },
+        "legend": { "displayMode": "list", "placement": "bottom" }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "min": 0,
+          "max": 100,
+          "custom": { "lineWidth": 2, "fillOpacity": 15 },
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 75 },
+              { "color": "red", "value": 90 }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 3,
+      "title": "Disk Usage (%)",
+      "type": "gauge",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "(1 - node_filesystem_avail_bytes{fstype!~\"tmpfs|overlay|squashfs\"} / node_filesystem_size_bytes{fstype!~\"tmpfs|overlay|squashfs\"}) * 100",
+          "legendFormat": "{{ mountpoint }}",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "orientation": "auto",
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "min": 0,
+          "max": 100,
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 75 },
+              { "color": "red", "value": 90 }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 4,
+      "title": "Network I/O (bytes/s)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "sum(rate(node_network_receive_bytes_total{device!~\"lo|docker.*|br-.*\"}[5m]))",
+          "legendFormat": "Receive",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(rate(node_network_transmit_bytes_total{device!~\"lo|docker.*|br-.*\"}[5m]))",
+          "legendFormat": "Transmit",
+          "refId": "B"
+        }
+      ],
+      "options": {
+        "tooltip": { "mode": "multi" },
+        "legend": { "displayMode": "list", "placement": "bottom" }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "Bps",
+          "custom": { "lineWidth": 2, "fillOpacity": 10 }
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "Transmit" },
+            "properties": [{ "id": "custom.transform", "value": "negative-Y" }]
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/monitoring/grafana/provisioning/dashboards/default.yml
+++ b/monitoring/grafana/provisioning/dashboards/default.yml
@@ -1,0 +1,11 @@
+apiVersion: 1
+
+providers:
+  - name: default
+    orgId: 1
+    folder: ShiftControl
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 30
+    options:
+      path: /etc/grafana/dashboards

--- a/monitoring/grafana/provisioning/datasources/prometheus.yml
+++ b/monitoring/grafana/provisioning/datasources/prometheus.yml
@@ -1,0 +1,12 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    uid: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: false
+    jsonData:
+      timeInterval: 15s

--- a/monitoring/prometheus/alerts/api_alerts.yml
+++ b/monitoring/prometheus/alerts/api_alerts.yml
@@ -1,0 +1,66 @@
+groups:
+  - name: api_alerts
+    interval: 30s
+    rules:
+
+      - alert: HighErrorRate
+        expr: |
+          (
+            sum(rate(http_requests_total{status_code=~"5.."}[5m]))
+            /
+            sum(rate(http_requests_total[5m]))
+          ) * 100 > 5
+        for: 5m
+        labels:
+          severity: critical
+          team: backend
+        annotations:
+          summary: "Высокий уровень ошибок API"
+          description: >-
+            Уровень 5xx ошибок {{ $value | printf "%.2f" }}%
+            превышает порог 5%
+          runbook_url: "https://github.com/LyutinAl/ShiftControl/wiki/runbooks/high-error-rate"
+
+      - alert: HighLatency
+        expr: |
+          histogram_quantile(0.95,
+            rate(http_request_duration_seconds_bucket[5m])
+          ) > 0.5
+        for: 10m
+        labels:
+          severity: warning
+          team: backend
+        annotations:
+          summary: "Высокая задержка API"
+          description: >-
+            P95 latency {{ $value | printf "%.3f" }}s превышает 500 мс
+          runbook_url: "https://github.com/LyutinAl/ShiftControl/wiki/runbooks/high-latency"
+
+      - alert: ServiceDown
+        expr: up{job="api"} == 0
+        for: 1m
+        labels:
+          severity: critical
+          team: backend
+        annotations:
+          summary: "Сервис API недоступен"
+          description: >-
+            Prometheus не может скрейпить метрики
+            с {{ $labels.instance }} более 1 минуты
+          runbook_url: "https://github.com/LyutinAl/ShiftControl/wiki/runbooks/service-down"
+
+      - alert: HighCPUUsage
+        expr: |
+          (
+            1 - avg(rate(node_cpu_seconds_total{mode="idle"}[5m]))
+          ) * 100 > 80
+        for: 5m
+        labels:
+          severity: warning
+          team: infrastructure
+        annotations:
+          summary: "Высокое использование CPU"
+          description: >-
+            CPU использует {{ $value | printf "%.1f" }}%,
+            порог 80%
+          runbook_url: "https://github.com/LyutinAl/ShiftControl/wiki/runbooks/high-cpu"


### PR DESCRIPTION
…O docs

- Add 4 Prometheus alert rules: HighErrorRate, HighLatency, ServiceDown, HighCPUUsage
- Configure Alertmanager with Yandex SMTP via env var substitution (start.sh + .env)
- Route critical alerts to email-critical, warning to email-warning
- Add inhibit rules to suppress warning when critical is firing
- Add slo_sli_definitions.md with 4 SLI/SLO definitions and PromQL examples
- Add .env.example template (credentials stay in gitignored .env)
- Upgrade alertmanager image to v0.27.0