### PR TITLE
feat(monitoring): add Loki/Promtail log aggregation and container log…

### DIFF
--- a/monitoring/docker-compose.yml
+++ b/monitoring/docker-compose.yml
@@ -16,6 +16,10 @@ services:
     networks:
       - monitoring
     restart: unless-stopped
+    logging:
+      driver: json-file
+      options:
+        tag: "{{.Name}}"
 
   grafana:
     image: grafana/grafana:10.1.0
@@ -35,6 +39,10 @@ services:
     restart: unless-stopped
     depends_on:
       - prometheus
+    logging:
+      driver: json-file
+      options:
+        tag: "{{.Name}}"
 
   loki:
     image: grafana/loki:2.9.0
@@ -43,11 +51,13 @@ services:
       - ./loki/loki.yml:/etc/loki/local-config.yaml
       - loki_data:/loki
     command: -config.file=/etc/loki/local-config.yaml
-    ports:
-      - "3100:3100"
     networks:
       - monitoring
     restart: unless-stopped
+    logging:
+      driver: json-file
+      options:
+        tag: "{{.Name}}"
 
   promtail:
     image: grafana/promtail:2.9.0
@@ -58,11 +68,17 @@ services:
       - /var/lib/docker/containers:/var/lib/docker/containers:ro
       - /var/run/docker.sock:/var/run/docker.sock
     command: -config.file=/etc/promtail/config.yml
+    ports:
+      - "9080:9080"
     networks:
       - monitoring
     restart: unless-stopped
     depends_on:
       - loki
+    logging:
+      driver: json-file
+      options:
+        tag: "{{.Name}}"
 
   alertmanager:
     image: prom/alertmanager:v0.27.0
@@ -79,6 +95,10 @@ services:
     networks:
       - monitoring
     restart: unless-stopped
+    logging:
+      driver: json-file
+      options:
+        tag: "{{.Name}}"
 
   node-exporter:
     image: prom/node-exporter:v1.6.1
@@ -97,6 +117,10 @@ services:
     networks:
       - monitoring
     restart: unless-stopped
+    logging:
+      driver: json-file
+      options:
+        tag: "{{.Name}}"
 
 networks:
   monitoring:

--- a/monitoring/grafana/dashboards/logs.json
+++ b/monitoring/grafana/dashboards/logs.json
@@ -1,0 +1,105 @@
+{
+  "title": "Container Logs",
+  "uid": "container-logs",
+  "tags": ["logs", "loki"],
+  "refresh": "30s",
+  "schemaVersion": 38,
+  "time": { "from": "now-1h", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "version": 1,
+  "templating": {
+    "list": [
+      {
+        "name": "container",
+        "label": "Container",
+        "type": "query",
+        "datasource": { "type": "loki", "uid": "loki" },
+        "query": "label_values(container)",
+        "refresh": 2,
+        "multi": false,
+        "includeAll": true,
+        "allValue": ".+",
+        "current": { "text": "All", "value": "$__all" },
+        "sort": 1
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "title": "Log Rate (lines/min)",
+      "type": "timeseries",
+      "gridPos": { "h": 5, "w": 24, "x": 0, "y": 0 },
+      "datasource": { "type": "loki", "uid": "loki" },
+      "targets": [
+        {
+          "expr": "sum by (container) (count_over_time({job=\"container-logs\", container=~\"$container\"}[1m]))",
+          "legendFormat": "{{ container }}",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "tooltip": { "mode": "multi" },
+        "legend": { "displayMode": "list", "placement": "bottom" }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": { "lineWidth": 1, "fillOpacity": 20 }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 2,
+      "title": "Error Rate (lines/min)",
+      "type": "timeseries",
+      "gridPos": { "h": 5, "w": 24, "x": 0, "y": 5 },
+      "datasource": { "type": "loki", "uid": "loki" },
+      "targets": [
+        {
+          "expr": "sum by (container) (count_over_time({job=\"container-logs\", container=~\"$container\"} |= \"error\" [1m]))",
+          "legendFormat": "{{ container }} errors",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "tooltip": { "mode": "multi" },
+        "legend": { "displayMode": "list", "placement": "bottom" }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": { "fixedColor": "red", "mode": "fixed" },
+          "custom": { "lineWidth": 1, "fillOpacity": 20 }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 3,
+      "title": "Logs — $container",
+      "type": "logs",
+      "gridPos": { "h": 16, "w": 24, "x": 0, "y": 10 },
+      "datasource": { "type": "loki", "uid": "loki" },
+      "targets": [
+        {
+          "expr": "{job=\"container-logs\", container=~\"$container\"}",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "dedupStrategy": "none",
+        "enableLogDetails": true,
+        "prettifyLogMessage": false,
+        "showCommonLabels": false,
+        "showLabels": true,
+        "showTime": true,
+        "sortOrder": "Descending",
+        "wrapLogMessage": false
+      }
+    }
+  ]
+}

--- a/monitoring/grafana/provisioning/datasources/prometheus.yml
+++ b/monitoring/grafana/provisioning/datasources/prometheus.yml
@@ -10,3 +10,11 @@ datasources:
     editable: false
     jsonData:
       timeInterval: 15s
+
+  - name: Loki
+    type: loki
+    uid: loki
+    access: proxy
+    url: http://loki:3100
+    isDefault: false
+    editable: false

--- a/monitoring/loki/loki.yml
+++ b/monitoring/loki/loki.yml
@@ -1,0 +1,29 @@
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+
+common:
+  path_prefix: /loki
+  storage:
+    filesystem:
+      chunks_directory: /loki/chunks
+      rules_directory: /loki/rules
+  replication_factor: 1
+  ring:
+    instance_addr: 127.0.0.1
+    kvstore:
+      store: inmemory
+
+schema_config:
+  configs:
+    - from: 2020-10-24
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+limits_config:
+  retention_period: 744h

--- a/monitoring/promtail/promtail.yml
+++ b/monitoring/promtail/promtail.yml
@@ -1,0 +1,33 @@
+server:
+  http_listen_port: 9080
+  grpc_listen_port: 0
+
+positions:
+  filename: /tmp/positions.yaml
+
+clients:
+  - url: http://loki:3100/loki/api/v1/push
+
+scrape_configs:
+  - job_name: containers
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: container-logs
+          __path__: /var/lib/docker/containers/*/*log
+
+    pipeline_stages:
+      - json:
+          expressions:
+            output: log
+            stream: stream
+            attrs: attrs
+      - regex:
+          source: attrs
+          expression: '"tag":"(?P<container>[^"]+)"'
+      - labels:
+          stream:
+          container:
+      - output:
+          source: output

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -54,6 +54,11 @@ resource "docker_container" "db" {
     "POSTGRES_PASSWORD=${var.postgres_password}",
   ]
 
+  log_driver = "json-file"
+  log_opts = {
+    tag = "{{.Name}}"
+  }
+
   volumes {
     volume_name    = docker_volume.postgres_data.name
     container_path = "/var/lib/postgresql/data"
@@ -77,6 +82,11 @@ resource "docker_container" "cache" {
   command = ["redis-server", "--appendonly", "yes"]
   restart = "unless-stopped"
 
+  log_driver = "json-file"
+  log_opts = {
+    tag = "{{.Name}}"
+  }
+
   volumes {
     volume_name    = docker_volume.redis_data.name
     container_path = "/data"
@@ -96,6 +106,11 @@ resource "docker_container" "backend" {
     "DATABASE_URL=postgresql+psycopg://${var.postgres_user}:${var.postgres_password}@${docker_container.db.name}:5432/${var.postgres_db}",
     "SECRET_KEY=${var.secret_key}",
   ]
+
+  log_driver = "json-file"
+  log_opts = {
+    tag = "{{.Name}}"
+  }
 
   ports {
     internal = 8000
@@ -122,6 +137,11 @@ resource "docker_container" "frontend" {
   name    = "shiftcontrol_frontend"
   image   = docker_image.frontend.image_id
   restart = "unless-stopped"
+
+  log_driver = "json-file"
+  log_opts = {
+    tag = "{{.Name}}"
+  }
 
   ports {
     internal = 80


### PR DESCRIPTION
… dashboard

- Add Loki (log storage) and Promtail (log collector) to monitoring stack
- Configure Promtail to scrape Docker container logs via static path
- Extract container name label via JSON pipeline + regex on attrs.tag
- Add json-file log driver with tag={{.Name}} to all docker-compose services
- Add json-file log driver with tag={{.Name}} to all Terraform containers
- Add Container Logs Grafana dashboard (log rate, error rate, logs panel)
- Expose Promtail port 9080 for status page access
- Add Loki datasource to Grafana provisioning