### PR TITLE
chore(ci): restrict ci-security.yml to manual dispatch

### DIFF
--- a/.github/workflows/ci-security.yml
+++ b/.github/workflows/ci-security.yml
@@ -2,10 +2,6 @@ name: Security
 
 on:
   workflow_dispatch:
-  pull_request:
-    branches: [main]
-  push:
-    branches: [main]
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true


### PR DESCRIPTION
Removes automatic push/PR triggers from ci-security.yml to avoid duplicate runs. All blocking security checks (Gitleaks, Trivy image scan) are already in ci.yml.