### PR TITLE
fix(security): move DAST to ci.yml as automated post-merge job

### DIFF
--- a/.github/workflows/ci-security.yml
+++ b/.github/workflows/ci-security.yml
@@ -125,74 +125,10 @@ jobs:
           upload-artifact: true
           artifact-name: sbom
 
-  dast:
-    name: DAST (OWASP ZAP Baseline)
-    runs-on: ubuntu-latest
-    services:
-      postgres:
-        image: postgres:17-alpine
-        env:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres  # pragma: allowlist secret
-          POSTGRES_DB: testdb
-        ports:
-          - 5432:5432
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-    env:
-      DATABASE_URL: postgresql+psycopg://postgres:postgres@localhost:5432/testdb  # pragma: allowlist secret
-      SECRET_KEY: dast-scan-ephemeral-key-not-production  # pragma: allowlist secret
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.14"
-
-      - name: Cache pip
-        uses: actions/cache@v5
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-dast-${{ hashFiles('backend/requirements.txt') }}
-          restore-keys: ${{ runner.os }}-pip-dast-
-
-      - name: Install dependencies
-        run: pip install -r backend/requirements.txt
-
-      - name: Run database migrations
-        working-directory: backend
-        run: alembic upgrade head
-
-      - name: Start backend
-        working-directory: backend
-        run: |
-          uvicorn main:app --host 0.0.0.0 --port 8000 &
-          echo $! > /tmp/uvicorn.pid
-          timeout 30 bash -c 'until curl -sf http://localhost:8000/health; do sleep 1; done'
-
-      - name: ZAP Baseline Scan
-        uses: zaproxy/action-baseline@v0.14.0
-        with:
-          target: 'http://localhost:8000'
-          cmd_options: '-I'
-          fail_action: true
-          allow_issue_writing: false
-
-      - name: Upload ZAP report
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: zap-report
-          path: report_html.html
-          if-no-files-found: ignore
-
   security-gate:
     name: Security Gate
     runs-on: ubuntu-latest
-    needs: [secret-detection, trivy-fs, trivy-image, sbom-generation, dast]
+    needs: [secret-detection, trivy-fs, trivy-image, sbom-generation]
     steps:
       - name: All security checks passed
-        run: echo "Security gate passed — Gitleaks, Trivy FS, Image Scan, SBOM, and DAST are clean"
+        run: echo "Security gate passed — Gitleaks, Trivy FS, Image Scan, and SBOM are clean"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -285,6 +285,72 @@ jobs:
       - name: All security checks passed
         run: echo "Security gate passed — SAST, SCA, Trivy FS, Image Scan, SBOM, and Secret Detection are clean"
 
+  dast:
+    name: Security / DAST (OWASP ZAP)
+    needs: [security-gate]
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    services:
+      postgres:
+        image: postgres:17-alpine
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres  # pragma: allowlist secret
+          POSTGRES_DB: testdb
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      DATABASE_URL: postgresql+psycopg://postgres:postgres@localhost:5432/testdb  # pragma: allowlist secret
+      SECRET_KEY: dast-scan-ephemeral-key-not-production  # pragma: allowlist secret
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.14"
+
+      - name: Cache pip
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-dast-${{ hashFiles('backend/requirements.txt') }}
+          restore-keys: ${{ runner.os }}-pip-dast-
+
+      - name: Install dependencies
+        run: pip install -r backend/requirements.txt
+
+      - name: Run database migrations
+        working-directory: backend
+        run: alembic upgrade head
+
+      - name: Start backend
+        working-directory: backend
+        run: |
+          uvicorn main:app --host 0.0.0.0 --port 8000 &
+          echo $! > /tmp/uvicorn.pid
+          timeout 30 bash -c 'until curl -sf http://localhost:8000/health; do sleep 1; done'
+
+      - name: ZAP Baseline Scan
+        uses: zaproxy/action-baseline@v0.14.0
+        with:
+          target: 'http://localhost:8000'
+          cmd_options: '-I'
+          fail_action: true
+          allow_issue_writing: false
+
+      - name: Upload ZAP report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: zap-report
+          path: report_html.html
+          if-no-files-found: ignore
+
   publish-backend:
     name: Publish Backend
     needs: [lint, test, security-gate]

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -34,6 +34,12 @@ tags = ["jwt", "token", "auth"]
 [allowlist]
   description = "ShiftControl project allowlist"
 
+  # Transitional commit: DAST job was briefly in ci-security.yml with test DATABASE_URL
+  # before being moved to ci.yml in the next commit
+  commits = [
+    "d5201ca5e2ab42af1c4a302c75837b939d1b8297",  # pragma: allowlist secret
+  ]
+
   regexes = [
     # CI test fixture — fake key, clearly labeled as non-production
     '''ci_test_secret_key_not_used_in_unit_tests''',
@@ -59,10 +65,8 @@ tags = ["jwt", "token", "auth"]
     '''terraform/terraform.tfvars.example$''',
     # DB URL built from Terraform variables — no hardcoded credentials
     '''terraform/main\.tf$''',
-    # CI test database — ephemeral postgres:postgres on localhost only
+    # CI test database and DAST job — ephemeral postgres:postgres on localhost only
     '''\.github/workflows/ci\.yml$''',
-    # DAST job uses same ephemeral postgres credentials for staging scan
-    '''\.github/workflows/ci-security\.yml$''',
     # docker-compose: DB URL uses ${VAR} substitution throughout history
     '''(^|/)docker-compose\.yml$''',
   ]


### PR DESCRIPTION
DAST now runs automatically on every push to main after security-gate passes, removing the need for manual workflow_dispatch. ci-security.yml reverts to manual-only extended scan without DAST. Gitleaks allowlist updated: ci-security.yml path entry removed, transitional commit allowlisted by hash (DAST was briefly in ci-security.yml before move).