### PR TITLE
fix(monitoring): use correct status label in Prometheus alert expressions

### DIFF
--- a/monitoring/prometheus/alerts/api_alerts.yml
+++ b/monitoring/prometheus/alerts/api_alerts.yml
@@ -6,7 +6,7 @@ groups:
       - alert: HighErrorRate
         expr: |
           (
-            sum(rate(http_requests_total{status_code=~"5.."}[5m]))
+            sum(rate(http_requests_total{status="5xx"}[5m]))
             /
             sum(rate(http_requests_total[5m]))
           ) * 100 > 5
@@ -72,7 +72,7 @@ groups:
       - alert: SuspiciousErrorSpike
         expr: |
           (
-            sum(rate(http_requests_total{status_code=~"5.."}[5m]))
+            sum(rate(http_requests_total{status="5xx"}[5m]))
             /
             sum(rate(http_requests_total[5m]))
           ) * 100 > 10
@@ -105,7 +105,7 @@ groups:
 
       - alert: AuthFailureSpike
         expr: |
-          sum(rate(http_requests_total{status_code="401"}[5m])) > 5
+          sum(rate(http_requests_total{status="4xx"}[5m])) > 5
         for: 3m
         labels:
           severity: warning


### PR DESCRIPTION
prometheus-fastapi-instrumentator exposes status as bucketed label ("2xx", "4xx", "5xx") not exact status codes. Fix all expressions:
  HighErrorRate, SuspiciousErrorSpike: status_code=~"5.." → status="5xx"
  AuthFailureSpike: status_code="401" → status="4xx"

Alert verified: AuthFailureSpike fired and email notification received.